### PR TITLE
Fix divider styling for app drawer in dark and light mode

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1612,7 +1612,14 @@ class _HomeScreenState extends State<HomeScreen> {
                               SliverToBoxAdapter(
                                 child: Column(
                                   children: [
-                                    const Divider(height: 32),
+                                    Divider(
+                                      height: 32,
+                                      color: Theme.of(context).brightness ==
+                                              Brightness.dark
+                                          ? Colors.grey[700]
+                                          : Colors.grey[300],
+                                      thickness: 2,
+                                    ),
                                     _buildDrawerItem(
                                       icon: Icons.add,
                                       title: 'Create New List',


### PR DESCRIPTION
The divider in the app drawer did not show in light mode due to an incorrect styling. This has been fixed.

Additionally, the thickness has been increased a little to improve legibility.