### PR TITLE
Updated page transition builders

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -68,17 +68,19 @@ class ShopSync extends StatelessWidget {
               TargetPlatform.windows: const FadeUpwardsPageTransitionsBuilder(),
               TargetPlatform.linux: const FadeUpwardsPageTransitionsBuilder(),
             },
-          )),
+          ),
+      ),
       darkTheme: ThemeData.dark().copyWith(
           pageTransitionsTheme: PageTransitionsTheme(
-        builders: {
-          TargetPlatform.android: const FadeForwardsPageTransitionsBuilder(),
-          TargetPlatform.iOS: const CupertinoPageTransitionsBuilder(),
-          TargetPlatform.macOS: const FadeUpwardsPageTransitionsBuilder(),
-          TargetPlatform.windows: const FadeUpwardsPageTransitionsBuilder(),
-          TargetPlatform.linux: const FadeUpwardsPageTransitionsBuilder(),
-        },
-      )),
+          builders: {
+              TargetPlatform.android: const FadeForwardsPageTransitionsBuilder(),
+              TargetPlatform.iOS: const CupertinoPageTransitionsBuilder(),
+              TargetPlatform.macOS: const ZoomPageTransitionsBuilder(),
+              TargetPlatform.linux: const ZoomPageTransitionsBuilder(),
+              TargetPlatform.windows: const FadeForwardsPageTransitionsBuilder(),
+          },
+        ),
+      ),
       // themeMode: themeNotifier.isDarkMode ? ThemeMode.dark : ThemeMode.light,
       home: const AuthWrapper(),
       routes: {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -61,12 +61,11 @@ class ShopSync extends StatelessWidget {
           colorScheme: ColorScheme.fromSwatch(primarySwatch: Colors.green),
           pageTransitionsTheme: PageTransitionsTheme(
             builders: {
-              TargetPlatform.android:
-                  const FadeForwardsPageTransitionsBuilder(),
+              TargetPlatform.android: const FadeForwardsPageTransitionsBuilder(),
               TargetPlatform.iOS: const CupertinoPageTransitionsBuilder(),
-              TargetPlatform.macOS: const FadeUpwardsPageTransitionsBuilder(),
-              TargetPlatform.windows: const FadeUpwardsPageTransitionsBuilder(),
-              TargetPlatform.linux: const FadeUpwardsPageTransitionsBuilder(),
+              TargetPlatform.macOS: const ZoomPageTransitionsBuilder(),
+              TargetPlatform.linux: const ZoomPageTransitionsBuilder(),
+              TargetPlatform.windows: const FadeForwardsPageTransitionsBuilder(),
             },
           ),
       ),


### PR DESCRIPTION
## 📌 Description

Changed the page transitions builders for macOS and Linux to ZoomPageTransitionsBuilder, and Windows to FadeForwardsPageTransitionsBuilder

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested this on Android
- [x] I have tested this on Web
- [x] I have added necessary tests or explain why not
- [x] I have updated documentation if needed

---
