### PR TITLE
Updated page transitions for a faster and smoother user experience

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -78,22 +78,22 @@ class ShopSync extends StatelessWidget {
         colorScheme: ColorScheme.fromSwatch(primarySwatch: Colors.green),
         pageTransitionsTheme: PageTransitionsTheme(
           builders: {
-            TargetPlatform.android: const FadeForwardsPageTransitionsBuilder(),
+            TargetPlatform.android: const ZoomPageTransitionsBuilder(),
             TargetPlatform.iOS: const CupertinoPageTransitionsBuilder(),
             TargetPlatform.macOS: const ZoomPageTransitionsBuilder(),
             TargetPlatform.linux: const ZoomPageTransitionsBuilder(),
-            TargetPlatform.windows: const FadeForwardsPageTransitionsBuilder(),
+            TargetPlatform.windows: const ZoomPageTransitionsBuilder(),
           },
         ),
       ),
       darkTheme: ThemeData.dark().copyWith(
         pageTransitionsTheme: PageTransitionsTheme(
           builders: {
-            TargetPlatform.android: const FadeForwardsPageTransitionsBuilder(),
+            TargetPlatform.android: const ZoomPageTransitionsBuilder(),
             TargetPlatform.iOS: const CupertinoPageTransitionsBuilder(),
             TargetPlatform.macOS: const ZoomPageTransitionsBuilder(),
             TargetPlatform.linux: const ZoomPageTransitionsBuilder(),
-            TargetPlatform.windows: const FadeForwardsPageTransitionsBuilder(),
+            TargetPlatform.windows: const ZoomPageTransitionsBuilder(),
           },
         ),
       ),


### PR DESCRIPTION
This pull request updates the page transition animations in the `ShopSync` class to provide a more consistent user experience across platforms. The most important change is the replacement of the `FadeForwardsPageTransitionsBuilder` with the `ZoomPageTransitionsBuilder` for Android and Windows platforms in both light and dark themes.

### Page transition updates:
* Replaced `FadeForwardsPageTransitionsBuilder` with `ZoomPageTransitionsBuilder` for `TargetPlatform.android` in both light and dark themes to align with other platforms. (`lib/main.dart`, [lib/main.dartL81-R96](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L81-R96))
* Replaced `FadeForwardsPageTransitionsBuilder` with `ZoomPageTransitionsBuilder` for `TargetPlatform.windows` in both light and dark themes to ensure consistency across platforms. (`lib/main.dart`, [lib/main.dartL81-R96](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L81-R96))