### PR TITLE
New viewer and editor permissions

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -17,6 +17,7 @@ import '/widgets/expandable_list_group_widget.dart';
 import '/widgets/splash_screen.dart';
 import '/services/list_groups_service.dart';
 import '/services/migration_service.dart';
+import '/utils/permissions.dart';
 
 class TutorialStep extends StatelessWidget {
   final IconData icon;
@@ -1403,6 +1404,48 @@ class _HomeScreenState extends State<HomeScreen> {
                       ),
                     ],
                   ),
+                ),
+                // Viewer indicator
+                FutureBuilder<bool>(
+                  future: PermissionsHelper.hasViewerLists(),
+                  builder: (context, snapshot) {
+                    if (snapshot.hasData && snapshot.data == true) {
+                      return Container(
+                        margin: const EdgeInsets.symmetric(
+                            horizontal: 16, vertical: 8),
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: isDark ? Colors.blue[900] : Colors.blue[50],
+                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(
+                            color:
+                                isDark ? Colors.blue[700]! : Colors.blue[200]!,
+                          ),
+                        ),
+                        child: Row(
+                          children: [
+                            Icon(
+                              FontAwesomeIcons.eye,
+                              color:
+                                  isDark ? Colors.blue[300] : Colors.blue[700],
+                              size: 16,
+                            ),
+                            const SizedBox(width: 8),
+                            Text(
+                              "You're a viewer",
+                              style: TextStyle(
+                                color: isDark
+                                    ? Colors.blue[300]
+                                    : Colors.blue[700],
+                                fontWeight: FontWeight.w500,
+                              ),
+                            ),
+                          ],
+                        ),
+                      );
+                    }
+                    return const SizedBox.shrink();
+                  },
                 ),
                 // Advertisement at the bottom
                 if (_isBannerAdLoaded && _bannerAd != null)

--- a/lib/screens/recycle_bin.dart
+++ b/lib/screens/recycle_bin.dart
@@ -5,6 +5,7 @@ import 'package:intl/intl.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 import '/widgets/loading_spinner.dart';
+import '/utils/permissions.dart';
 
 class AppBarClipper extends CustomClipper<Path> {
   @override
@@ -323,26 +324,38 @@ class _RecycleBinScreenState extends State<RecycleBinScreen>
                                     ),
                                   ],
                                 ),
-                                trailing: Row(
-                                  mainAxisSize: MainAxisSize.min,
-                                  children: [
-                                    IconButton(
-                                      icon: Icon(
-                                        Icons.restore,
-                                        color: Colors.green[600],
-                                      ),
-                                      onPressed: () =>
-                                          _restoreItem(doc.id, itemData),
-                                    ),
-                                    IconButton(
-                                      icon: const Icon(
-                                        Icons.delete_forever,
-                                        color: Colors.red,
-                                      ),
-                                      onPressed: () =>
-                                          _deletePermanently(doc.id),
-                                    ),
-                                  ],
+                                trailing: FutureBuilder<bool>(
+                                  future:
+                                      PermissionsHelper.isViewer(widget.listId),
+                                  builder: (context, permissionSnapshot) {
+                                    // Hide action buttons for viewers
+                                    if (permissionSnapshot.hasData &&
+                                        permissionSnapshot.data == true) {
+                                      return const SizedBox.shrink();
+                                    }
+
+                                    return Row(
+                                      mainAxisSize: MainAxisSize.min,
+                                      children: [
+                                        IconButton(
+                                          icon: Icon(
+                                            Icons.restore,
+                                            color: Colors.green[600],
+                                          ),
+                                          onPressed: () =>
+                                              _restoreItem(doc.id, itemData),
+                                        ),
+                                        IconButton(
+                                          icon: const Icon(
+                                            Icons.delete_forever,
+                                            color: Colors.red,
+                                          ),
+                                          onPressed: () =>
+                                              _deletePermanently(doc.id),
+                                        ),
+                                      ],
+                                    );
+                                  },
                                 ),
                               ),
                             ),

--- a/lib/utils/permissions.dart
+++ b/lib/utils/permissions.dart
@@ -1,0 +1,84 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+class PermissionsHelper {
+  static final _firestore = FirebaseFirestore.instance;
+  static final _auth = FirebaseAuth.instance;
+
+  /// Check if the current user is a viewer for a given list
+  static Future<bool> isViewer(String listId) async {
+    final currentUserId = _auth.currentUser?.uid;
+    if (currentUserId == null)
+      return true; // Default to viewer if not authenticated
+
+    try {
+      final listDoc = await _firestore.collection('lists').doc(listId).get();
+      if (!listDoc.exists) return true;
+
+      final data = listDoc.data() as Map<String, dynamic>;
+
+      // Check if user is the owner
+      if (data['createdBy'] == currentUserId) return false;
+
+      // Check member role
+      final memberRoles = Map<String, String>.from(data['memberRoles'] ?? {});
+      final userRole = memberRoles[currentUserId] ?? 'viewer';
+
+      return userRole == 'viewer';
+    } catch (e) {
+      return true; // Default to viewer on error
+    }
+  }
+
+  /// Get the role of the current user for a given list
+  static Future<String> getUserRole(String listId) async {
+    final currentUserId = _auth.currentUser?.uid;
+    if (currentUserId == null) return 'viewer';
+
+    try {
+      final listDoc = await _firestore.collection('lists').doc(listId).get();
+      if (!listDoc.exists) return 'viewer';
+
+      final data = listDoc.data() as Map<String, dynamic>;
+
+      // Check if user is the owner
+      if (data['createdBy'] == currentUserId) return 'owner';
+
+      // Check member role
+      final memberRoles = Map<String, String>.from(data['memberRoles'] ?? {});
+      return memberRoles[currentUserId] ?? 'viewer';
+    } catch (e) {
+      return 'viewer';
+    }
+  }
+
+  /// Check if current user has any viewer-only lists
+  static Future<bool> hasViewerLists() async {
+    final currentUserId = _auth.currentUser?.uid;
+    if (currentUserId == null) return false;
+
+    try {
+      final listsSnapshot = await _firestore
+          .collection('lists')
+          .where('members', arrayContains: currentUserId)
+          .get();
+
+      for (final doc in listsSnapshot.docs) {
+        final data = doc.data();
+
+        // Skip if user is the owner
+        if (data['createdBy'] == currentUserId) continue;
+
+        // Check member role
+        final memberRoles = Map<String, String>.from(data['memberRoles'] ?? {});
+        final userRole = memberRoles[currentUserId] ?? 'viewer';
+
+        if (userRole == 'viewer') return true;
+      }
+
+      return false;
+    } catch (e) {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces role-based permissions across multiple screens, enhancing the app's functionality by distinguishing between viewers and editors. Key changes include role management, UI updates to reflect permissions, and backend integration for storing and updating roles.

### Role-based permissions implementation:

* **Viewer indicator in `HomeScreen`:** Added a UI element to display a viewer badge for users with viewer permissions. (`lib/screens/home.dart`, [lib/screens/home.dartR1408-R1449](diffhunk://#diff-3c4164a8346a87854665f200ffb80f341d7b09f063ca86e40d8d6f6dd1109509R1408-R1449))
* **Role management in `ListOptionsScreen`:** Integrated role-based restrictions for list management, templates, export, and recycle bin sections. Viewers have limited access, while owners retain full control. (`lib/screens/list_options.dart`, [[1]](diffhunk://#diff-5749577c380e4cc2684ba5749995c2c4af6ee93dd0994c414fdfc547a3163eb2R327-R339) [[2]](diffhunk://#diff-5749577c380e4cc2684ba5749995c2c4af6ee93dd0994c414fdfc547a3163eb2R363-R378) [[3]](diffhunk://#diff-5749577c380e4cc2684ba5749995c2c4af6ee93dd0994c414fdfc547a3163eb2L368-R398) [[4]](diffhunk://#diff-5749577c380e4cc2684ba5749995c2c4af6ee93dd0994c414fdfc547a3163eb2R417-R422) [[5]](diffhunk://#diff-5749577c380e4cc2684ba5749995c2c4af6ee93dd0994c414fdfc547a3163eb2R438)
* **Sharing permissions in `ShareMenuScreen`:** Added functionality to assign roles (editor/viewer) when sharing a list, change roles for members, and display roles in the member list. (`lib/screens/list_options.dart`, [[1]](diffhunk://#diff-5749577c380e4cc2684ba5749995c2c4af6ee93dd0994c414fdfc547a3163eb2R566-R567) [[2]](diffhunk://#diff-5749577c380e4cc2684ba5749995c2c4af6ee93dd0994c414fdfc547a3163eb2L594-R629) [[3]](diffhunk://#diff-5749577c380e4cc2684ba5749995c2c4af6ee93dd0994c414fdfc547a3163eb2R647) [[4]](diffhunk://#diff-5749577c380e4cc2684ba5749995c2c4af6ee93dd0994c414fdfc547a3163eb2R665-R774) [[5]](diffhunk://#diff-5749577c380e4cc2684ba5749995c2c4af6ee93dd0994c414fdfc547a3163eb2R939-R940) [[6]](diffhunk://#diff-5749577c380e4cc2684ba5749995c2c4af6ee93dd0994c414fdfc547a3163eb2R1002-R1003) [[7]](diffhunk://#diff-5749577c380e4cc2684ba5749995c2c4af6ee93dd0994c414fdfc547a3163eb2R1040-R1078)

### Backend integration:

* **Firestore updates for roles:** Modified Firestore operations to store roles in `memberRoles` and handle role updates/removals. (`lib/screens/list_options.dart`, [[1]](diffhunk://#diff-5749577c380e4cc2684ba5749995c2c4af6ee93dd0994c414fdfc547a3163eb2L594-R629) [[2]](diffhunk://#diff-5749577c380e4cc2684ba5749995c2c4af6ee93dd0994c414fdfc547a3163eb2R647) [[3]](diffhunk://#diff-5749577c380e4cc2684ba5749995c2c4af6ee93dd0994c414fdfc547a3163eb2R665-R774)

### UI enhancements:

* **Floating Action Button visibility in `ListViewScreen`:** Restricted access to the FAB for viewers, ensuring they cannot add tasks. (`lib/screens/list_view.dart`, [lib/screens/list_view.dartL242-R250](diffhunk://#diff-95bbdc90a1de9f29a5325254e91a5e97016e9ded6b5d1ad6b2dab48c22d65e8fL242-R250))

### Code organization:

* **Utility imports:** Added `permissions.dart` utility imports to relevant files for role-checking functionality. (`lib/screens/home.dart`, [[1]](diffhunk://#diff-3c4164a8346a87854665f200ffb80f341d7b09f063ca86e40d8d6f6dd1109509R20); `lib/screens/list_options.dart`, [[2]](diffhunk://#diff-5749577c380e4cc2684ba5749995c2c4af6ee93dd0994c414fdfc547a3163eb2R12); `lib/screens/list_view.dart`, [[3]](diffhunk://#diff-95bbdc90a1de9f29a5325254e91a5e97016e9ded6b5d1ad6b2dab48c22d65e8fR13)