### PR TITLE
Added spacing in between List Management and Recycle Bin sections in the list options screen.

### DIFF
--- a/lib/screens/list_options.dart
+++ b/lib/screens/list_options.dart
@@ -380,6 +380,8 @@ class _ListOptionsScreenState extends State<ListOptionsScreen> {
                         ],
                       ),
 
+                    if (!isViewer) const SizedBox(height: 16),
+
                     // Recycle Bin - Always visible but limited for viewers
                     _buildSectionCard(
                       title: 'Recycle Bin',


### PR DESCRIPTION
This pull request introduces a minor UI improvement in the `ListOptionsScreen` to enhance layout spacing for non-viewer users.

* [`lib/screens/list_options.dart`](diffhunk://#diff-5749577c380e4cc2684ba5749995c2c4af6ee93dd0994c414fdfc547a3163eb2R383-R384): Added a conditional `SizedBox` with a height of 16 pixels to create additional spacing above the "Recycle Bin" section, but only for non-viewer users.